### PR TITLE
Extract figure generation in separate files

### DIFF
--- a/app/calculations.py
+++ b/app/calculations.py
@@ -1,12 +1,6 @@
 from app.utilities import df_plot, df_filter, det_col
 
 
-def calculate_cap_df(all_params, years):
-    cap_df = all_params['TotalCapacityAnnual'][all_params['TotalCapacityAnnual'].t.str.startswith(
-        'PWR')].drop('r', axis=1)
-    return df_filter(cap_df, 3, 6, ['CNT', 'TRN', 'CST', 'CEN', 'SOU', 'NOR'], years)
-
-
 def calculate_gen_df(all_params, years):
     # Power generation (Detailed)
     gen_df = all_params['ProductionByTechnologyAnnual'][(all_params['ProductionByTechnologyAnnual'].t.str.startswith('PWR') |

--- a/app/constants.py
+++ b/app/constants.py
@@ -1,0 +1,9 @@
+# List of columns for aggregated energy tables and figures
+agg_col = {'Coal': ['Coal'],
+           'Oil': ['Diesel', 'HFO', 'JFL', 'Crude oil', 'Petroleum coke'],
+           'Gas': ['Natural gas', 'LNG', 'LPG'],
+           'Hydro': ['Hydro'],
+           'Nuclear': ['Nuclear'],
+           'Other renewables': ['Biomass', 'Geothermal', 'Solar', 'MSW', 'Wind'],
+           'Net electricity imports': ['Net electricity imports']
+           }

--- a/app/figures/power_generation_capacity.py
+++ b/app/figures/power_generation_capacity.py
@@ -1,0 +1,17 @@
+from app.utilities import df_plot, df_filter
+
+
+class PowerGenerationCapacity:
+
+    def __init__(self, all_params, years):
+        self.all_params = all_params
+        self.years = years
+
+    def figure(self):
+        return df_plot(self.__cap_df(), 'Gigawatts (GW)', 'Power Generation Capacity (Detail)')
+
+    def __cap_df(self):
+        total_capacity_annual_params = self.all_params['TotalCapacityAnnual']
+        cap_df = total_capacity_annual_params[total_capacity_annual_params.t.str.startswith('PWR')]\
+            .drop('r', axis=1)
+        return df_filter(cap_df, 3, 6, ['CNT', 'TRN', 'CST', 'CEN', 'SOU', 'NOR'], self.years)

--- a/app/figures/power_generation_capacity_aggregate.py
+++ b/app/figures/power_generation_capacity_aggregate.py
@@ -1,0 +1,30 @@
+from app.utilities import df_plot, df_filter
+import pandas as pd
+from app.constants import agg_col
+
+
+class PowerGenerationCapacityAggregate:
+
+    def __init__(self, all_params, years):
+        self.all_params = all_params
+        self.years = years
+
+    def figure(self):
+        cap_agg_df = pd.DataFrame(columns=agg_col)
+        cap_agg_df.insert(0, 'y', self.__cap_df()['y'])
+        cap_agg_df = cap_agg_df.fillna(0.00)
+
+        for each in agg_col:
+            for tech_exists in agg_col[each]:
+                if tech_exists in self.__cap_df().columns:
+                    cap_agg_df[each] = cap_agg_df[each] + self.__cap_df()[tech_exists]
+                    cap_agg_df[each] = cap_agg_df[each].round(2)
+
+        cap_agg_df = cap_agg_df.loc[:, (cap_agg_df != 0).any(axis=0)]
+        return df_plot(cap_agg_df, 'Gigawatts (GW)', 'Power Generation Capacity (Aggregate)')
+
+    def __cap_df(self):
+        total_capacity_annual_params = self.all_params['TotalCapacityAnnual']
+        cap_df = total_capacity_annual_params[total_capacity_annual_params.t.str.startswith('PWR')]\
+            .drop('r', axis=1)
+        return df_filter(cap_df, 3, 6, ['CNT', 'TRN', 'CST', 'CEN', 'SOU', 'NOR'], self.years)

--- a/app/generate_figures.py
+++ b/app/generate_figures.py
@@ -1,9 +1,11 @@
-from app.figures import *
+from app.old_figures import *
 import os
 import pandas as pd
 from app.config import Config
 from app.land_use import LandUse
 from app.result_parser import ResultParser
+from app.figures.power_generation_capacity import PowerGenerationCapacity
+from app.figures.power_generation_capacity_aggregate import PowerGenerationCapacityAggregate
 pd.set_option('mode.chained_assignment', None)
 
 
@@ -17,8 +19,8 @@ def generate_figures(url):
     years = result_parser.years
 
     figure_list = [
-            fig1(all_params, years),
-            fig2(all_params, years),
+            PowerGenerationCapacity(all_params, years).figure(),
+            PowerGenerationCapacityAggregate(all_params, years).figure(),
             fig3(all_params, years),
             fig4(all_params, years),
             fig5(all_params, years),

--- a/app/old_figures.py
+++ b/app/old_figures.py
@@ -3,50 +3,8 @@ from app.calculations import *
 from app.utilities import df_plot, det_col, df_years
 import pandas as pd
 from app.land_use import LandUse
+from app.constants import agg_col
 pd.set_option('mode.chained_assignment', None)
-
-
-# List of columns for aggregated energy tables and figures
-agg_col = {'Coal': ['Coal'],
-           'Oil': ['Diesel', 'HFO', 'JFL', 'Crude oil', 'Petroleum coke'],
-           'Gas': ['Natural gas', 'LNG', 'LPG'],
-           'Hydro': ['Hydro'],
-           'Nuclear': ['Nuclear'],
-           'Other renewables': ['Biomass', 'Geothermal', 'Solar', 'MSW', 'Wind'],
-           'Net electricity imports': ['Net electricity imports']
-           }
-
-# ## Energy figures
-# This section contains figures related to specifically to the energy sector.
-# The list of figures in this section are as follows:
-# 1. Power generation capacity (detailed)
-# 2. Power generation capacity (aggregated)
-# 3. Power generation (detailed)
-# 4. Power generation (aggregated)
-
-
-def fig1(all_params, years):
-    # ### Power generation capacity
-    # Power generation capacity (detailed)
-    cap_df = calculate_cap_df(all_params, years)
-    return df_plot(cap_df, 'Gigawatts (GW)', 'Power Generation Capacity (Detail)')
-
-
-def fig2(all_params, years):
-    cap_df = calculate_cap_df(all_params, years)
-    # Power generation capacity (Aggregated)
-    cap_agg_df = pd.DataFrame(columns=agg_col)
-    cap_agg_df.insert(0, 'y', cap_df['y'])
-    cap_agg_df = cap_agg_df.fillna(0.00)
-
-    for each in agg_col:
-        for tech_exists in agg_col[each]:
-            if tech_exists in cap_df.columns:
-                cap_agg_df[each] = cap_agg_df[each] + cap_df[tech_exists]
-                cap_agg_df[each] = cap_agg_df[each].round(2)
-
-    cap_agg_df = cap_agg_df.loc[:, (cap_agg_df != 0).any(axis=0)]
-    return df_plot(cap_agg_df, 'Gigawatts (GW)', 'Power Generation Capacity (Aggregate)')
 
 
 def fig3(all_params, years):


### PR DESCRIPTION
This Pull Request is a proposal to organize the code for generating our figures
in a more modular way.

Instead of putting all the figures in the same `figures` file, this creates a
`figures` module, with one file per figure.

In this file, we have a class that takes `all_params` and `years` as inputs and
has one `figure()` function that generates the figure. The necessary calculations
to generate the figure are in the same class and file (instead of a separate 
`calculations` file). This makes for smaller, more self-contained files.

We also have more explicit names for our figures: `PowerGenerationCapacity` and
`PowerGenerationCapacityAggregate` instead of `fig1` and `fig2`. This will make
finding the right figures easier when we have a lot of them.

Other changes that were made to make this possible:
- Extracted the `agg_col` variable in the `app.constants` module.
- Renamed the `figures` file to `old_figures` to avoid name clash with the new
`figures` module.