### PR TITLE
Fixed mode_list for missing crop_combos

### DIFF
--- a/app/land_use.py
+++ b/app/land_use.py
@@ -26,13 +26,16 @@ class LandUse:
 
     def mode_crop_combo(self):
         # Construct dictionary mapping modes to crop combos {mode:crop_combo}
-        crop_list = sorted(list(set([x[1:5] for x in self.commodities if x.startswith('LCP')])))
+        crop_list = sorted(list(set([x[1:7] for x in self.commodities if x.startswith('LCP')])))
         crop_order = ['HI', 'II', 'HR', 'IR', 'LR']
         crop_combo = []
 
         for each_crop in crop_list:
             for each_combo in crop_order:
-                crop_combo.append(each_crop + each_combo)
+                if each_crop[0:4] + each_combo in crop_list:
+                    crop_combo.append(each_crop[0:4] + each_combo)
+        
+        crop_combo = list(set(crop_combo))
 
         for each in ['BAR', 'FOR', 'GRS', 'BLT', 'WAT', 'OTH']:
             crop_combo.append(each)


### PR DESCRIPTION
Fixed a bug where models with some missing crop combos were not being visualised correctly. For e.g., Teff has only 3 crop_combos but the default is 5 so all the succesive modes were offset by 2.