### PR TITLE
Add config.language() to read the run's language

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -37,6 +37,9 @@ class Config:
     def model_name(self):
         return self.__metadata().get('model_name', '(No model)')
 
+    def language(self):
+        return self.__metadata().get('language', 'en')
+
     def __metadata(self):
         if not self.is_valid():
             return self.__default_metadata()

--- a/data/workshop/metadata.json
+++ b/data/workshop/metadata.json
@@ -1,1 +1,1 @@
-{"run_name":"Workshop run","version_name":"v2020","description":"Workshop description","model_name":"Workshop model"}
+{"run_name":"Workshop run","version_name":"v2020","description":"Workshop description","model_name":"Workshop model", "language":"es"}


### PR DESCRIPTION
As of https://github.com/yboulkaid/osemosys-cloud/pull/218, we now capture the user's
language in the `metadata.json` file. This gives us access to this variable so that we can
use it in our logic.

The two possible values for now are `en` and `es`.